### PR TITLE
Support Secret Seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@
 # keycloakclient-controller
 The keycloakclient-controller **manages keycloak clients in independent keycloak installations**. 
 
-To create a KeycloakClient in a Keycloak Installation, a **KeycloakClient-CustomResource** is created, and the keycloakclient-controller sees to creating, changing, deleting the KeycloakClient as specified with the CustomResource.
+A basic configuration for the keycloakcontroller consists of 
+* a keycloak-cr with the url of the keycloak, where clients should be managed
+* a keycloakrealm cr with the realm-name, in which clients should be managed (and a selector of the keycloak-cr of this realm)
+* a keycloakclient-cr with the client specific setting (which are quite a few) and a selector of the realm of this client
+* for each keycloak-cr a secret "credential-<keycloak-cr.name> that contains the following data
+  * ADMIN_PASSWORD: if the controller logs in via admin-consile and grant_type password, not recommended
+  * ADMIN_USERNAME: 
+  * KEYCLOAKCLIENT_CONTROLLER_NAME: if the controller logs in via a special service account and grant_type client_credentials, recommended 
+  * KEYCLOAKCLIENT_CONTROLLER_PASSWORD:
+  
+* optional secret credential-keycloak-client-secret-seed in namespace des controllers
+  * SECRET_SEED if the secret for each client should be created via a sha code of (secret-seed + client-name). This is sometimes necessary if a controller should be running in twho separate k8s clusters.
+
+
+
+To create a KeycloakClient in a Keycloak Installation, a **KeycloakClient-CustomResource** is created, and the keycloakclient-controller sees to creating, changing, deleting the KeycloakClient as specified with the CustomResource (and the referenced keycloakrealm-cr and keycloak-cr)
 
 
 ## Description

--- a/controllers/keycloakclient_controller.go
+++ b/controllers/keycloakclient_controller.go
@@ -204,7 +204,10 @@ func (r *KeycloakClientReconciler) manageSuccess(client *kc.KeycloakClient, dele
 		logKcc.Info(fmt.Sprintf("added finalizer to keycloak client %v/%v",
 			client.Namespace,
 			client.Spec.Client.ClientID))
-
+		sha, _ := GetClientShaCode(client.Spec.Client.ClientID)
+		if client.Spec.Client.Secret == sha {
+			client.Spec.Client.Secret = ""
+		}
 		return r.Client.Update(r.context, client)
 	}
 

--- a/controllers/keycloakclient_controller.go
+++ b/controllers/keycloakclient_controller.go
@@ -205,8 +205,8 @@ func (r *KeycloakClientReconciler) manageSuccess(client *kc.KeycloakClient, dele
 		logKcc.Info(fmt.Sprintf("added finalizer to keycloak client %v/%v",
 			client.Namespace,
 			client.Spec.Client.ClientID))
-		sha, _ := GetClientShaCode(client.Spec.Client.ClientID)
-		if client.Spec.Client.Secret == sha {
+		sha, err := GetClientShaCode(client.Spec.Client.ClientID)
+		if err == nil && client.Spec.Client.Secret == sha {
 			client.Spec.Client.Secret = ""
 		}
 		return r.Client.Update(r.context, client)

--- a/controllers/keycloakclient_controller.go
+++ b/controllers/keycloakclient_controller.go
@@ -184,14 +184,6 @@ func (r *KeycloakClientReconciler) manageSuccess(client *kc.KeycloakClient, dele
 		logKcc.Error(err, "unable to update status")
 	}
 
-	if client.Spec.Client.Secret != "" {
-		client.Spec.Client.Secret = ""
-		err := r.Client.Update(r.context, client)
-		if err != nil {
-			logKcc.Error(err, "unable to remove secret from keycloakclient"+client.Spec.Client.Name)
-		}
-	}
-
 	// Finalizer already set?
 	finalizerExists := false
 	for _, finalizer := range client.Finalizers {

--- a/controllers/keycloakclient_controller.go
+++ b/controllers/keycloakclient_controller.go
@@ -123,6 +123,7 @@ func (r *KeycloakClientReconciler) Reconcile(ctx context.Context, request ctrl.R
 				instance.Namespace,
 				instance.Name))
 
+			// if keycloak has stored a secret, then this is added to instance here
 			err = clientState.Read(r.context, instance, authenticated, r.Client)
 			if err != nil {
 				logKcc.Error(err, "error reading client state")

--- a/controllers/keycloakclient_reconciler.go
+++ b/controllers/keycloakclient_reconciler.go
@@ -67,7 +67,7 @@ func getSecretSeed() (string, error) {
 
 	controllerNamespace, err := k8sutil.GetControllerNamespace()
 	if err != nil {
-		controllerNamespace = model.DEFAULT_CONTROLLER_NAMESPACE
+		controllerNamespace = model.DefaultControllerNamespace
 	}
 	secretSeedSecret, err := secretClient.CoreV1().Secrets(controllerNamespace).Get(context.TODO(), model.SecretSeedSecretName, v12.GetOptions{})
 	if err != nil {

--- a/controllers/keycloakclient_reconciler.go
+++ b/controllers/keycloakclient_reconciler.go
@@ -103,7 +103,7 @@ func (i *DedicatedKeycloakClientReconciler) ReconcileIt(state *common.ClientStat
 	}
 
 	if state.ClientSecret == nil {
-		logKcc.Info("unexpected missing k8s secret")
+		logKcc.Info("k8s secret for client is missing, create it")
 		desired.AddAction(i.getCreatedClientSecretState(state, cr))
 	} else {
 		desired.AddAction(i.getUpdatedClientSecretState(state, cr))

--- a/controllers/keycloakclient_reconciler.go
+++ b/controllers/keycloakclient_reconciler.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 
+	"github.com/movewp3/keycloakclient-controller/pkg/k8sutil"
+
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +65,11 @@ func getSecretSeed() (string, error) {
 		return "", err
 	}
 
-	secretSeedSecret, err := secretClient.CoreV1().Secrets("keycloak").Get(context.TODO(), model.SecretSeedSecretName, v12.GetOptions{})
+	controllerNamespace, err := k8sutil.GetControllerNamespace()
+	if err != nil {
+		controllerNamespace = model.DEFAULT_CONTROLLER_NAMESPACE
+	}
+	secretSeedSecret, err := secretClient.CoreV1().Secrets(controllerNamespace).Get(context.TODO(), model.SecretSeedSecretName, v12.GetOptions{})
 	if err != nil {
 
 		if !kubeerrors.IsNotFound(err) {

--- a/controllers/keycloakclient_reconciler.go
+++ b/controllers/keycloakclient_reconciler.go
@@ -103,7 +103,7 @@ func (i *DedicatedKeycloakClientReconciler) ReconcileIt(state *common.ClientStat
 	}
 
 	if state.ClientSecret == nil {
-		logKcc.Info("k8s secret for client is missing, create it")
+		logKcc.Info("k8s secret for client is missing, create it for " + cr.Spec.Client.ClientID)
 		desired.AddAction(i.getCreatedClientSecretState(state, cr))
 	} else {
 		desired.AddAction(i.getUpdatedClientSecretState(state, cr))

--- a/controllers/keycloakclient_reconciler.go
+++ b/controllers/keycloakclient_reconciler.go
@@ -92,8 +92,11 @@ func (i *DedicatedKeycloakClientReconciler) ReconcileIt(state *common.ClientStat
 			}
 		}
 		desired.AddAction(i.getCreatedClientState(state, cr))
-	} else {
+	} else { // keycloakclient already exists in keycloak
 		if cr.Spec.Client.Secret == "" {
+			// at this place the cr has the secret if there was a secret in keycloak, even if nothing was specified in the cr
+			// the secret should stay stable if possible. if a secret was created already, then cont change it.
+			// if it should be changed, then delete the client in keycloak and the controller will create a new one with a secret
 			sha, err := GetClientShaCode(cr.Spec.Client.ClientID)
 			if err == nil {
 				cr.Spec.Client.Secret = sha

--- a/pkg/common/client.go
+++ b/pkg/common/client.go
@@ -690,6 +690,7 @@ func (c *Client) GetServiceAccountUser(realmName, clientID string) (*v1alpha1.Ke
 
 // login requests a new auth token from Keycloak
 func (c *Client) login_admin(user, pass string) error {
+	logClient.Info("start login with adminuser")
 	form := url.Values{}
 	form.Add("username", user)
 	form.Add("password", pass)
@@ -730,6 +731,7 @@ func (c *Client) login_admin(user, pass string) error {
 	}
 
 	c.token = tokenRes.AccessToken
+	logClient.Info("login with adminuser succeeded")
 
 	return nil
 }

--- a/pkg/common/client.go
+++ b/pkg/common/client.go
@@ -93,8 +93,8 @@ func (c *Client) CreateRealm(realm *v1alpha1.KeycloakRealm) (string, error) {
 	return c.create(realm.Spec.Realm, "realms", "realm")
 }
 
-func (c *Client) CreateClient(client *v1alpha1.KeycloakAPIClient, realmName string) (string, error) {
-	return c.create(client, fmt.Sprintf("realms/%s/clients", realmName), "client")
+func (c *Client) CreateClient(specClient *v1alpha1.KeycloakAPIClient, realmName string) (string, error) {
+	return c.create(specClient, fmt.Sprintf("realms/%s/clients", realmName), "client")
 }
 
 func (c *Client) CreateClientRole(clientID string, role *v1alpha1.RoleRepresentation, realmName string) (string, error) {
@@ -689,7 +689,7 @@ func (c *Client) GetServiceAccountUser(realmName, clientID string) (*v1alpha1.Ke
 }
 
 // login requests a new auth token from Keycloak
-func (c *Client) login_old(user, pass string) error {
+func (c *Client) login_admin(user, pass string) error {
 	form := url.Values{}
 	form.Add("username", user)
 	form.Add("password", pass)
@@ -771,7 +771,7 @@ func (c *Client) login(client, credential string) error {
 	}
 
 	if tokenRes.Error != "" {
-		logClient.Error(errors.New(tokenRes.Error), "error with request: %s", tokenRes.ErrorDescription)
+		logClient.Error(errors.New(tokenRes.Error), fmt.Sprintf("error with request: %s", tokenRes.ErrorDescription))
 		return errors.Errorf(tokenRes.ErrorDescription)
 	}
 
@@ -930,15 +930,16 @@ func (i *LocalConfigKeycloakFactory) AuthenticatedClient(kc v1alpha1.Keycloak, i
 		URL:       kcURL,
 		requester: requester,
 	}
+
 	if clientName != "" && clientCredential != "" {
-		client.login(clientName, clientCredential)
-		if err := client.login_old(user, pass); err != nil {
-			if err := client.login_old(user, pass); err != nil {
+		err := client.login(clientName, clientCredential)
+		if err != nil {
+			if err := client.login_admin(user, pass); err != nil {
 				return nil, err
 			}
 		}
 	} else {
-		if err := client.login_old(user, pass); err != nil {
+		if err := client.login_admin(user, pass); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -3,7 +3,7 @@ package model
 // Constants for a community Keycloak installation
 const (
 	ApplicationName                  = "keycloak"
-	DEFAULT_CONTROLLER_NAMESPACE     = "keycloak"
+	DefaultControllerNamespace       = "keycloak"
 	AdminUsernameProperty            = "ADMIN_USERNAME"
 	AdminPasswordProperty            = "ADMIN_PASSWORD"
 	ClientName                       = "KEYCLOAKCLIENT_CONTROLLER_NAME"

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -3,6 +3,7 @@ package model
 // Constants for a community Keycloak installation
 const (
 	ApplicationName                  = "keycloak"
+	DEFAULT_CONTROLLER_NAMESPACE     = "keycloak"
 	AdminUsernameProperty            = "ADMIN_USERNAME"
 	AdminPasswordProperty            = "ADMIN_PASSWORD"
 	ClientName                       = "KEYCLOAKCLIENT_CONTROLLER_NAME"

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -7,6 +7,9 @@ const (
 	AdminPasswordProperty            = "ADMIN_PASSWORD"
 	ClientName                       = "KEYCLOAKCLIENT_CONTROLLER_NAME"
 	ClientPassword                   = "KEYCLOAKCLIENT_CONTROLLER_PASSWORD"
+	KeycloakClientSecretSeed         = "SECRET_SEED"
+	SecretSeedSecretName             = "credential-keycloak-client-secret-seed"
+	SALT                             = "803%%1Pas$3cow++#"
 	ServingCertSecretName            = "sso-x509-https-secret" // nolint
 	ClientSecretName                 = ApplicationName + "-client-secret"
 	ClientSecretClientIDProperty     = "CLIENT_ID"

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -3,12 +3,13 @@ package e2e
 import "time"
 
 const (
-	testKeycloakCRName             = "keycloakx-test"
-	testKeycloakRealmCRName        = "keycloakx-realm-test"
-	testKeycloakClientCRName       = "keycloakx-client-test"
-	testAuthZKeycloakClientCRName  = "authz-keycloak-client-test"
-	testSecondKeycloakClientCRName = "second-keycloak-client-test"
-	pollRetryInterval              = time.Second * 10
-	pollTimeout                    = time.Minute * 1
-	keycloakNamespace              = "keycloak"
+	testKeycloakCRName                   = "keycloakx-test"
+	testKeycloakRealmCRName              = "keycloakx-realm-test"
+	testKeycloakClientCRName             = "keycloakx-client-test"
+	testKeycloakConfidentialClientCRName = "a"
+	testAuthZKeycloakClientCRName        = "authz-keycloak-client-test"
+	testSecondKeycloakClientCRName       = "second-keycloak-client-test"
+	pollRetryInterval                    = time.Second * 10
+	pollTimeout                          = time.Minute * 1
+	keycloakNamespace                    = "keycloak"
 )

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"reflect"
 	"sort"
@@ -460,7 +461,7 @@ func keycloakClientWithSecretSeedTest() error {
 		return err
 	}
 	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
-	if retrievedSecret.StringData["CLIENT_SECRET"] != expectedSecret {
+	if string(retrievedSecret.Data["CLIENT_SECRET"]) != base64.StdEncoding.EncodeToString([]byte(expectedSecret)) {
 		return errors.Wrap(errors.New("if a keycloakclient doesn´t set a secret, it should not be set"), secret.Name)
 	}
 

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -47,17 +47,16 @@ var _ = Describe("KeycloakClient", func() {
 		Expect(err).To(BeNil())
 		tearDownKeycloakClients()
 	})
-	/*
-		Describe("keycloakClientWithSecretSeedTest", func() {
-			BeforeEach(func() {
-				getKeycloakConfidentialClientCR("")
-			})
-			It("test client with secret seed", func() {
-				err := keycloakClientWithSecretSeedTest()
-				Expect(err).To(BeNil())
-			})
+
+	Describe("keycloakClientWithSecretSeedTest", func() {
+		BeforeEach(func() {
+			getKeycloakConfidentialClientCR("")
 		})
-	*/
+		It("test client with secret seed", func() {
+			err := keycloakClientWithSecretSeedTest()
+			Expect(err).To(BeNil())
+		})
+	})
 
 	Describe("keycloakClientSecretIsSetWhenChangedTest", func() {
 		BeforeEach(func() {

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -473,6 +473,10 @@ func keycloakClientWithSecretSeedTest() error {
 	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
 
 	fmt.Println("expectedSecret " + expectedSecret)
+	fmt.Println("retrievedSecret " + retrievedSecret.Name)
+	for key, v := range retrievedSecret.Data {
+		fmt.Println("retrievedSecret " + key + " " + string(v))
+	}
 	fmt.Println("retrievedSecret " + string(retrievedSecret.Data["CLIENT_SECRET"]))
 	val, err := base64.StdEncoding.DecodeString(string(retrievedSecret.Data["CLIENT_SECRET"]))
 	fmt.Println("retrievedSecret " + string(val))

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -119,7 +119,7 @@ var _ = Describe("KeycloakClient", func() {
 		BeforeEach(func() {
 			getKeycloakConfidentialClientCR()
 		})
-		It("test basic client", func() {
+		It("test client with secret seed", func() {
 			err := keycloakClientWithSecretSeedTest()
 			Expect(err).To(BeNil())
 		})
@@ -431,14 +431,21 @@ func keycloakClientWithSecretSeedTest() error {
 	// create client secret using client ID, i.e., keycloak-client-secret-<CLIENT_ID>
 	err := CreateSecret(secret)
 	if err != nil {
+
 		return err
 	}
 
+	fmt.Println("secret create: " + secret.ObjectMeta.Name)
+
 	// create client
+	fmt.Println("create client " + client.Spec.Client.ClientID)
 	client, err = CreateKeycloakClient(client)
+	fmt.Println("create client err" + err.Error())
+
 	if err != nil {
 		return err
 	}
+	fmt.Println("wait for client " + testKeycloakClientCRName)
 	err = WaitForClientToBeReady(keycloakNamespace, testKeycloakClientCRName)
 	if err != nil {
 		return err

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -474,7 +474,7 @@ func keycloakClientWithSecretSeedTest() error {
 
 	fmt.Println("expectedSecret " + expectedSecret)
 	fmt.Println("retrievedSecret " + string(retrievedSecret.Data["CLIENT_SECRET"]))
-	val, err := base64.StdEncoding.DecodeString(string(retrievedSecret.Data["CLIENT_SECRET"])))
+	val, err := base64.StdEncoding.DecodeString(string(retrievedSecret.Data["CLIENT_SECRET"]))
 	fmt.Println("retrievedSecret " + string(val))
 
 	if string(retrievedSecret.Data["CLIENT_SECRET"]) != base64.StdEncoding.EncodeToString([]byte(expectedSecret)) {

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -46,6 +46,17 @@ var _ = Describe("KeycloakClient", func() {
 		tearDownKeycloakClients()
 	})
 
+	Describe("keycloakClientWithSecretSeedTest", func() {
+		//XXXXXX
+		BeforeEach(func() {
+			getKeycloakConfidentialClientCR()
+		})
+		It("test client with secret seed", func() {
+			err := keycloakClientWithSecretSeedTest()
+			Expect(err).To(BeNil())
+		})
+	})
+
 	Describe("keycloakClientBasicTest", func() {
 		BeforeEach(func() {
 			prepareKeycloakClientCR()
@@ -110,17 +121,6 @@ var _ = Describe("KeycloakClient", func() {
 	Describe("keycloakClientServiceAccountRealmRolesTest", func() {
 		It("test basic client", func() {
 			err := keycloakClientServiceAccountRealmRolesTest()
-			Expect(err).To(BeNil())
-		})
-	})
-
-	Describe("keycloakClientWithSecretSeedTest", func() {
-		//XXXXXX
-		BeforeEach(func() {
-			getKeycloakConfidentialClientCR()
-		})
-		It("test client with secret seed", func() {
-			err := keycloakClientWithSecretSeedTest()
 			Expect(err).To(BeNil())
 		})
 	})
@@ -466,16 +466,18 @@ func keycloakClientWithSecretSeedTest() error {
 
 	// verify client secret removal
 	var retrievedSecret v1.Secret
+	fmt.Println("search secret  " + keycloakNamespace + " " + "keycloak-client-secret-" + testKeycloakClientCRName)
 	err = GetNamespacedSecret(keycloakNamespace, "keycloak-client-secret-"+testKeycloakClientCRName, &retrievedSecret)
-	if !apierrors.IsNotFound(err) {
+	if err != nil {
+		fmt.Println("error search secret  " + keycloakNamespace + " " + "keycloak-client-secret-" + testKeycloakClientCRName + " " + err.Error())
 		return err
 	}
 	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
 
 	fmt.Println("expectedSecret " + expectedSecret)
-	fmt.Println("retrievedSecret " + retrievedSecret.Name)
+	fmt.Println("retrievedSecret name " + retrievedSecret.Name)
 	for key, v := range retrievedSecret.Data {
-		fmt.Println("retrievedSecret " + key + " " + string(v))
+		fmt.Println("retrievedSecret data" + key + " " + string(v))
 	}
 	fmt.Println("retrievedSecret " + string(retrievedSecret.Data["CLIENT_SECRET"]))
 	val, err := base64.StdEncoding.DecodeString(string(retrievedSecret.Data["CLIENT_SECRET"]))

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -446,8 +446,8 @@ func keycloakClientWithSecretSeedTest() error {
 		return err
 	}
 
-	fmt.Println("wait for client " + testKeycloakClientCRName)
-	err = WaitForClientToBeReady(keycloakNamespace, testKeycloakClientCRName)
+	fmt.Println("wait for client " + testKeycloakConfidentialClientCRName)
+	err = WaitForClientToBeReady(keycloakNamespace, testKeycloakConfidentialClientCRName)
 	if err != nil {
 
 		fmt.Println("wait for client err" + err.Error())

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -57,17 +57,17 @@ var _ = Describe("KeycloakClient", func() {
 				Expect(err).To(BeNil())
 			})
 		})
-
-		Describe("keycloakClientSecretIsSetWhenChangedTest", func() {
-			BeforeEach(func() {
-				getKeycloakConfidentialClientCR("")
-			})
-			It("test client with secret seed when secret is set", func() {
-				err := keycloakClientSecretIsSetWhenChangedTest()
-				Expect(err).To(BeNil())
-			})
-		})
 	*/
+
+	Describe("keycloakClientSecretIsSetWhenChangedTest", func() {
+		BeforeEach(func() {
+			getKeycloakConfidentialClientCR("")
+		})
+		It("test client with secret seed when secret is set", func() {
+			err := keycloakClientSecretIsSetWhenChangedTest()
+			Expect(err).To(BeNil())
+		})
+	})
 	Describe("keycloakClientSecretStaysWhenSecretSettingIsRemovedTest", func() {
 		BeforeEach(func() {
 			getKeycloakConfidentialClientCR("")

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -440,14 +440,17 @@ func keycloakClientWithSecretSeedTest() error {
 	// create client
 	fmt.Println("create client " + client.Spec.Client.ClientID)
 	client, err = CreateKeycloakClient(client)
-	fmt.Println("create client err" + err.Error())
 
 	if err != nil {
+		fmt.Println("create client err" + err.Error())
 		return err
 	}
+
 	fmt.Println("wait for client " + testKeycloakClientCRName)
 	err = WaitForClientToBeReady(keycloakNamespace, testKeycloakClientCRName)
 	if err != nil {
+
+		fmt.Println("wait for client err" + err.Error())
 		return err
 	}
 

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -834,7 +834,7 @@ func keycloakClientSecretUpdatesToSecretSeedWhenClientIsRemoved() error {
 	UpdateKeycloakClient(keycloakNamespace, newClient)
 	fmt.Println("Updated keycloakclient")
 
-	time.Sleep(30 * time.Second)
+	time.Sleep(300 * time.Second)
 
 	secretName = "keycloak-client-secret-" + testKeycloakConfidentialClientCRName
 	fmt.Println("search secret  " + keycloakNamespace + " " + secretName)

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -172,8 +172,8 @@ func getKeycloakClientCR() *keycloakv1alpha1.KeycloakClient {
 }
 
 func getKeycloakConfidentialClientCR() *keycloakv1alpha1.KeycloakClient {
-	k8sName := testKeycloakClientCRName
-	id := testKeycloakClientCRName
+	k8sName := testKeycloakConfidentialClientCRName
+	id := testKeycloakConfidentialClientCRName
 	labels := CreateLabel(keycloakNamespace)
 
 	return &keycloakv1alpha1.KeycloakClient{
@@ -458,18 +458,12 @@ func keycloakClientWithSecretSeedTest() error {
 		return errors.Wrap(ErrSecretSetInKeycloakclient, client.Spec.Client.ClientID)
 	}
 
-	// verify client secret removal in secondary resources
-	_, exists := client.Status.SecondaryResources[secret.Name]
-	if exists {
-		return errors.Wrap(ErrDeprecatedClientSecretFound, secret.Name)
-	}
-
 	// verify client secret removal
 	var retrievedSecret v1.Secret
-	fmt.Println("search secret  " + keycloakNamespace + " " + "keycloak-client-secret-" + testKeycloakClientCRName)
-	err = GetNamespacedSecret(keycloakNamespace, "keycloak-client-secret-"+testKeycloakClientCRName, &retrievedSecret)
+	fmt.Println("search secret  " + keycloakNamespace + " " + "keycloak-client-secret-" + testKeycloakConfidentialClientCRName)
+	err = GetNamespacedSecret(keycloakNamespace, "keycloak-client-secret-"+testKeycloakConfidentialClientCRName, &retrievedSecret)
 	if err != nil {
-		fmt.Println("error search secret  " + keycloakNamespace + " " + "keycloak-client-secret-" + testKeycloakClientCRName + " " + err.Error())
+		fmt.Println("error search secret  " + keycloakNamespace + " " + "keycloak-client-secret-" + testKeycloakConfidentialClientCRName + " " + err.Error())
 		return err
 	}
 	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
@@ -487,8 +481,8 @@ func keycloakClientWithSecretSeedTest() error {
 		return errors.Wrap(errors.New("if a keycloakclient doesn´t set a secret, the sha code with salt should be used"), secret.Name)
 	}
 
-	fmt.Println("read keycloakclient " + keycloakNamespace + " " + testKeycloakClientCRName)
-	newClient, err := GetNamespacedKeycloakClient(keycloakNamespace, testKeycloakClientCRName)
+	fmt.Println("read keycloakclient " + keycloakNamespace + " " + testKeycloakConfidentialClientCRName)
+	newClient, err := GetNamespacedKeycloakClient(keycloakNamespace, testKeycloakConfidentialClientCRName)
 
 	fmt.Println("keycloakclient secret: " + newClient.Spec.Client.Secret)
 

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -460,12 +460,21 @@ func keycloakClientWithSecretSeedTest() error {
 
 	// verify client secret removal
 	var retrievedSecret v1.Secret
-	fmt.Println("search secret  " + keycloakNamespace + " " + "keycloak-client-secret-" + testKeycloakConfidentialClientCRName)
-	err = GetNamespacedSecret(keycloakNamespace, "keycloak-client-secret-"+testKeycloakConfidentialClientCRName, &retrievedSecret)
+	secretName := "keycloak-client-secret-" + testKeycloakConfidentialClientCRName
+	fmt.Println("search secret  " + keycloakNamespace + " " + secretName)
+	err = GetNamespacedSecret(keycloakNamespace, secretName, &retrievedSecret)
 	if err != nil {
-		fmt.Println("error search secret  " + keycloakNamespace + " " + "keycloak-client-secret-" + testKeycloakConfidentialClientCRName + " " + err.Error())
+		fmt.Println("error search secret  " + keycloakNamespace + " " + secretName + " " + err.Error())
+	}
+	secretName = testKeycloakCRName + "-client-secret-" + testKeycloakConfidentialClientCRName
+
+	fmt.Println("search secret  " + keycloakNamespace + " " + secretName)
+	err = GetNamespacedSecret(keycloakNamespace, secretName, &retrievedSecret)
+	if err != nil {
+		fmt.Println("error search secret  " + keycloakNamespace + " " + secretName + " " + err.Error())
 		return err
 	}
+
 	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
 
 	fmt.Println("expectedSecret " + expectedSecret)

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -47,42 +47,33 @@ var _ = Describe("KeycloakClient", func() {
 		Expect(err).To(BeNil())
 		tearDownKeycloakClients()
 	})
+	/*
+		Describe("keycloakClientWithSecretSeedTest", func() {
+			BeforeEach(func() {
+				getKeycloakConfidentialClientCR("")
+			})
+			It("test client with secret seed", func() {
+				err := keycloakClientWithSecretSeedTest()
+				Expect(err).To(BeNil())
+			})
+		})
 
-	Describe("keycloakClientWithSecretSeedTest", func() {
-		BeforeEach(func() {
-			getKeycloakConfidentialClientCR("")
+		Describe("keycloakClientSecretIsSetWhenChangedTest", func() {
+			BeforeEach(func() {
+				getKeycloakConfidentialClientCR("")
+			})
+			It("test client with secret seed when secret is set", func() {
+				err := keycloakClientSecretIsSetWhenChangedTest()
+				Expect(err).To(BeNil())
+			})
 		})
-		It("test client with secret seed", func() {
-			err := keycloakClientWithSecretSeedTest()
-			Expect(err).To(BeNil())
-		})
-	})
-
-	Describe("keycloakClientSecretIsSetWhenChangedTest", func() {
-		BeforeEach(func() {
-			getKeycloakConfidentialClientCR("")
-		})
-		It("test client with secret seed when secret is set", func() {
-			err := keycloakClientSecretIsSetWhenChangedTest()
-			Expect(err).To(BeNil())
-		})
-	})
-
+	*/
 	Describe("keycloakClientSecretStaysWhenSecretSettingIsRemovedTest", func() {
 		BeforeEach(func() {
 			getKeycloakConfidentialClientCR("")
 		})
 		It("test client with secret seed when secret is set", func() {
 			err := keycloakClientSecretStaysWhenSecretSettingIsRemovedTest()
-			Expect(err).To(BeNil())
-		})
-	})
-	Describe("keycloakClientSecretIsSetWhenChangedTest", func() {
-		BeforeEach(func() {
-			getKeycloakConfidentialClientCR("")
-		})
-		It("test client with secret seed when secret is set", func() {
-			err := keycloakClientSecretIsSetWhenChangedTest()
 			Expect(err).To(BeNil())
 		})
 	})

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 
 	"github.com/movewp3/keycloakclient-controller/controllers"
 
@@ -475,6 +476,10 @@ func keycloakClientWithSecretSeedTest() error {
 		return err
 	}
 
+	list, err := ListSecret()
+	for i, item := range list.Items {
+		fmt.Println("secrets found " + strconv.Itoa(i) + " " + item.Name)
+	}
 	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
 
 	fmt.Println("expectedSecret " + expectedSecret)

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -496,6 +496,7 @@ func keycloakClientWithSecretSeedTest() error {
 		return errors.Wrap(errors.New("if a keycloakclient doesn´t set a secret, created secret should not be stored in the cr keycloakclient"), secret.Name)
 	}
 
+	DeleteSecret("credential-keycloak-client-secret-seed")
 	return nil
 }
 

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/movewp3/keycloakclient-controller/controllers"
 	"reflect"
 	"sort"
 	"strconv"
-
-	"github.com/movewp3/keycloakclient-controller/controllers"
 
 	keycloakv1alpha1 "github.com/movewp3/keycloakclient-controller/api/v1alpha1"
 	"github.com/movewp3/keycloakclient-controller/pkg/common"
@@ -461,6 +460,12 @@ func keycloakClientWithSecretSeedTest() error {
 
 	// verify client secret removal
 	var retrievedSecret v1.Secret
+
+	list, err := ListSecret()
+	for i, item := range list.Items {
+		fmt.Println("secrets found " + strconv.Itoa(i) + " " + item.Name)
+	}
+
 	secretName := "keycloak-client-secret-" + testKeycloakConfidentialClientCRName
 	fmt.Println("search secret  " + keycloakNamespace + " " + secretName)
 	err = GetNamespacedSecret(keycloakNamespace, secretName, &retrievedSecret)
@@ -476,10 +481,6 @@ func keycloakClientWithSecretSeedTest() error {
 		return err
 	}
 
-	list, err := ListSecret()
-	for i, item := range list.Items {
-		fmt.Println("secrets found " + strconv.Itoa(i) + " " + item.Name)
-	}
 	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
 
 	fmt.Println("expectedSecret " + expectedSecret)

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -810,13 +810,15 @@ func keycloakClientSecretUpdatesToSecretSeedWhenClientIsRemoved() error {
 		return errors.New("if a keycloakclient secret was set in the past, it should not be changed if unset")
 	}
 
-	fmt.Println("Delete Client in Keycloak")
+	fmt.Println("Make AuthenticatedClient")
 
 	keycloakCR, err := getDeployedKeycloakCR(keycloakNamespace)
 	authenticatedClient, err := MakeAuthenticatedClient(*keycloakCR)
 	if err != nil {
 		return errors.Wrap(errors.New("cloud not create authenticated client"), err.Error())
 	}
+	fmt.Println("Made AuthenticatedClient")
+	fmt.Println("Delete Client in Keycloak")
 	err = authenticatedClient.DeleteClient(client.Spec.Client.ClientID, realmName)
 	fmt.Println("Deleted Client in Keycloak" + err.Error())
 	time.Sleep(30 * time.Second)
@@ -831,7 +833,7 @@ func keycloakClientSecretUpdatesToSecretSeedWhenClientIsRemoved() error {
 	UpdateKeycloakClient(keycloakNamespace, newClient)
 	fmt.Println("Updated keycloakclient")
 
-	time.Sleep(300 * time.Second)
+	time.Sleep(30 * time.Second)
 
 	secretName = "keycloak-client-secret-" + testKeycloakConfidentialClientCRName
 	fmt.Println("search secret  " + keycloakNamespace + " " + secretName)

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -76,7 +76,15 @@ var _ = Describe("KeycloakClient", func() {
 			Expect(err).To(BeNil())
 		})
 	})
-
+	Describe("keycloakClientSecretUpdatesToSecretSeedWhenClientIsRemoved", func() {
+		BeforeEach(func() {
+			getKeycloakConfidentialClientCR("")
+		})
+		It("test client with secret seed when secret is set", func() {
+			err := keycloakClientSecretUpdatesToSecretSeedWhenClientIsRemoved()
+			Expect(err).To(BeNil())
+		})
+	})
 	Describe("keycloakClientBasicTest", func() {
 		BeforeEach(func() {
 			prepareKeycloakClientCR()

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -820,7 +820,10 @@ func keycloakClientSecretUpdatesToSecretSeedWhenClientIsRemoved() error {
 	fmt.Println("Made AuthenticatedClient")
 	fmt.Println("Delete Client in Keycloak")
 	err = authenticatedClient.DeleteClient(client.Spec.Client.ClientID, realmName)
-	fmt.Println("Deleted Client in Keycloak" + err.Error())
+	fmt.Println("Deleted Client in Keycloak")
+	if err != nil {
+		fmt.Println("Deleted Client in Keycloak" + err.Error())
+	}
 	time.Sleep(30 * time.Second)
 
 	fmt.Println("Update keycloakclient")

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -471,6 +471,12 @@ func keycloakClientWithSecretSeedTest() error {
 		return err
 	}
 	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
+
+	fmt.Println("expectedSecret " + expectedSecret)
+	fmt.Println("retrievedSecret " + string(retrievedSecret.Data["CLIENT_SECRET"]))
+	val, err := base64.StdEncoding.DecodeString(string(retrievedSecret.Data["CLIENT_SECRET"])))
+	fmt.Println("retrievedSecret " + string(val))
+
 	if string(retrievedSecret.Data["CLIENT_SECRET"]) != base64.StdEncoding.EncodeToString([]byte(expectedSecret)) {
 		return errors.Wrap(errors.New("if a keycloakclient doesn´t set a secret, it should not be set"), secret.Name)
 	}

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -499,7 +499,10 @@ func keycloakClientWithSecretSeedTest() error {
 		fmt.Println("error search secret  " + keycloakNamespace + " " + secretName + " " + err.Error())
 	}
 
-	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
+	expectedSecret, err := controllers.GetClientShaCode(client.Spec.Client.ClientID)
+	if err != nil {
+		fmt.Println("error getting sha code " + err.Error())
+	}
 
 	fmt.Println("expectedSecret " + expectedSecret)
 	fmt.Println("retrievedSecret name " + retrievedSecret.Name)
@@ -584,7 +587,10 @@ func keycloakClientSecretIsSetWhenChangedTest() error {
 		fmt.Println("error search secret  " + keycloakNamespace + " " + secretName + " " + err.Error())
 	}
 
-	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
+	expectedSecret, err := controllers.GetClientShaCode(client.Spec.Client.ClientID)
+	if err != nil {
+		fmt.Println("error getting sha code " + err.Error())
+	}
 
 	fmt.Println("expectedSecret " + expectedSecret)
 	fmt.Println("retrievedSecret name " + retrievedSecret.Name)
@@ -845,7 +851,10 @@ func keycloakClientSecretUpdatesToSecretSeedWhenClientIsRemoved() error {
 		fmt.Println("error search secret  " + keycloakNamespace + " " + secretName + " " + err.Error())
 	}
 
-	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
+	expectedSecret, err := controllers.GetClientShaCode(client.Spec.Client.ClientID)
+	if err != nil {
+		fmt.Println("error getting sha code " + err.Error())
+	}
 
 	fmt.Println("expectedSecret " + expectedSecret)
 	fmt.Println("retrievedSecret name " + retrievedSecret.Name)

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -480,7 +480,7 @@ func keycloakClientWithSecretSeedTest() error {
 	val, err := base64.StdEncoding.DecodeString(string(retrievedSecret.Data["CLIENT_SECRET"]))
 	fmt.Println("retrievedSecret " + string(val))
 
-	if string(retrievedSecret.Data["CLIENT_SECRET"]) != base64.StdEncoding.EncodeToString([]byte(expectedSecret)) {
+	if string(retrievedSecret.Data["CLIENT_SECRET"]) != expectedSecret {
 		return errors.Wrap(errors.New("if a keycloakclient doesn´t set a secret, the sha code with salt should be used"), secret.Name)
 	}
 

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -817,17 +817,14 @@ func keycloakClientSecretUpdatesToSecretSeedWhenClientIsRemoved() error {
 	if err != nil {
 		return errors.Wrap(errors.New("cloud not create authenticated client"), err.Error())
 	}
-	authenticatedClient.DeleteClient(client.Spec.Client.ClientID, realmName)
-	fmt.Println("Deleted Client in Keycloak")
+	err = authenticatedClient.DeleteClient(client.Spec.Client.ClientID, realmName)
+	fmt.Println("Deleted Client in Keycloak" + err.Error())
 	time.Sleep(30 * time.Second)
-
-	err = DeleteSecret(model.SecretSeedSecretName)
-	if err != nil {
-		fmt.Println("error deleting secret " + model.SecretSeedSecretName)
-	}
 
 	fmt.Println("Update keycloakclient")
 	newClient, err = GetNamespacedKeycloakClient(keycloakNamespace, testKeycloakConfidentialClientCRName)
+	fmt.Println("secret in keycloakclient" + newClient.Spec.Client.Secret)
+	newClient.Spec.Client.Secret = ""
 	labels = newClient.ObjectMeta.GetLabels()
 	labels["cwdude2"] = "value"
 	newClient.ObjectMeta.SetLabels(labels)

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/movewp3/keycloakclient-controller/controllers"
 
@@ -48,12 +49,21 @@ var _ = Describe("KeycloakClient", func() {
 	})
 
 	Describe("keycloakClientWithSecretSeedTest", func() {
-		//XXXXXX
 		BeforeEach(func() {
-			getKeycloakConfidentialClientCR()
+			getKeycloakConfidentialClientCR("")
 		})
 		It("test client with secret seed", func() {
 			err := keycloakClientWithSecretSeedTest()
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Describe("keycloakClientSecretIsSetWhenChangedTest", func() {
+		BeforeEach(func() {
+			getKeycloakConfidentialClientCR("")
+		})
+		It("test client with secret seed when secret is set", func() {
+			err := keycloakClientSecretIsSetWhenChangedTest()
 			Expect(err).To(BeNil())
 		})
 	})
@@ -172,12 +182,12 @@ func getKeycloakClientCR() *keycloakv1alpha1.KeycloakClient {
 	}
 }
 
-func getKeycloakConfidentialClientCR() *keycloakv1alpha1.KeycloakClient {
+func getKeycloakConfidentialClientCR(secret string) *keycloakv1alpha1.KeycloakClient {
 	k8sName := testKeycloakConfidentialClientCRName
 	id := testKeycloakConfidentialClientCRName
 	labels := CreateLabel(keycloakNamespace)
 
-	return &keycloakv1alpha1.KeycloakClient{
+	kcc := &keycloakv1alpha1.KeycloakClient{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sName,
 			Namespace: keycloakNamespace,
@@ -214,6 +224,10 @@ func getKeycloakConfidentialClientCR() *keycloakv1alpha1.KeycloakClient {
 			},
 		},
 	}
+	if secret != "" {
+		kcc.Spec.Client.Secret = secret
+	}
+	return kcc
 }
 
 func getKeycloakClientAuthZCR() *keycloakv1alpha1.KeycloakClient {
@@ -416,7 +430,7 @@ func keycloakClientDeprecatedClientSecretTest() error {
 
 func keycloakClientWithSecretSeedTest() error {
 	//XXXXXXXXXXX
-	client := getKeycloakConfidentialClientCR()
+	client := getKeycloakConfidentialClientCR("")
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "credential-keycloak-client-secret-seed",
@@ -491,6 +505,100 @@ func keycloakClientWithSecretSeedTest() error {
 
 	if newClient.Spec.Client.Secret != "" {
 		return errors.Wrap(errors.New("if a keycloakclient doesn´t set a secret, created secret should not be stored in the cr keycloakclient"), secret.Name)
+	}
+
+	DeleteSecret("credential-keycloak-client-secret-seed")
+	return nil
+}
+
+func keycloakClientSecretIsSetWhenChangedTest() error {
+	client := getKeycloakConfidentialClientCR("")
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "credential-keycloak-client-secret-seed",
+			Namespace: keycloakNamespace,
+		},
+		StringData: map[string]string{
+			"SECRET_SEED": "aHZ5c0FhcTRTUlFWNGFzddddbnVBSzQ4SnMzZ3hUTEU=,",
+		},
+	}
+
+	// create client secret using client ID, i.e., keycloak-client-secret-<CLIENT_ID>
+	err := CreateSecret(secret)
+	if err != nil {
+
+		return err
+	}
+
+	fmt.Println("secret create: " + secret.ObjectMeta.Name)
+
+	// create client
+	fmt.Println("create client " + client.Spec.Client.ClientID)
+	client, err = CreateKeycloakClient(client)
+
+	if err != nil {
+		fmt.Println("create client err" + err.Error())
+		return err
+	}
+
+	fmt.Println("wait for client " + testKeycloakConfidentialClientCRName)
+	err = WaitForClientToBeReady(keycloakNamespace, testKeycloakConfidentialClientCRName)
+	if err != nil {
+
+		fmt.Println("wait for client err" + err.Error())
+		return err
+	}
+
+	if client.Spec.Client.Secret != "" {
+		return errors.Wrap(ErrSecretSetInKeycloakclient, client.Spec.Client.ClientID)
+	}
+
+	list, err := ListSecret()
+	for i, item := range list.Items {
+		fmt.Println("secrets found " + strconv.Itoa(i) + " " + item.Name)
+	}
+
+	secretName := "keycloak-client-secret-" + testKeycloakConfidentialClientCRName
+	fmt.Println("search secret  " + keycloakNamespace + " " + secretName)
+	retrievedSecret, err := GetSecret(secretName)
+	if err != nil {
+		fmt.Println("error search secret  " + keycloakNamespace + " " + secretName + " " + err.Error())
+	}
+
+	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)
+
+	fmt.Println("expectedSecret " + expectedSecret)
+	fmt.Println("retrievedSecret name " + retrievedSecret.Name)
+	for key, v := range retrievedSecret.Data {
+		fmt.Println("retrievedSecret data" + key + " " + string(v))
+	}
+	fmt.Println("retrievedSecret " + string(retrievedSecret.Data["CLIENT_SECRET"]))
+	val, err := base64.StdEncoding.DecodeString(string(retrievedSecret.Data["CLIENT_SECRET"]))
+	fmt.Println("retrievedSecret " + string(val))
+
+	if string(retrievedSecret.Data["CLIENT_SECRET"]) != expectedSecret {
+		return errors.Wrap(errors.New("if a keycloakclient doesn´t set a secret, the sha code with salt should be used"), secret.Name)
+	}
+
+	fmt.Println("read keycloakclient " + keycloakNamespace + " " + testKeycloakConfidentialClientCRName)
+	newClient, err := GetNamespacedKeycloakClient(keycloakNamespace, testKeycloakConfidentialClientCRName)
+
+	fmt.Println("keycloakclient secret: " + newClient.Spec.Client.Secret)
+
+	if newClient.Spec.Client.Secret != "" {
+		return errors.Wrap(errors.New("if a keycloakclient doesn´t set a secret, created secret should not be stored in the cr keycloakclient"), secret.Name)
+	}
+
+	// change secret and check that is it used
+	client.Spec.Client.Secret = "duh"
+	UpdateKeycloakClient(keycloakNamespace, client)
+	time.Sleep(10 * time.Second)
+	retrievedSecret, err = GetSecret(secretName)
+	if err != nil {
+		fmt.Println("error search secret  " + keycloakNamespace + " " + secretName + " " + err.Error())
+	}
+	if string(retrievedSecret.Data["CLIENT_SECRET"]) != "duh" {
+		return errors.Wrap(errors.New("if a keycloakclient secret is set, it has to be reflected in the kubernetes secret"), secret.Name)
 	}
 
 	DeleteSecret("credential-keycloak-client-secret-seed")

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/movewp3/keycloakclient-controller/controllers"
 	"reflect"
 	"sort"
 	"strconv"
+
+	"github.com/movewp3/keycloakclient-controller/controllers"
 
 	keycloakv1alpha1 "github.com/movewp3/keycloakclient-controller/api/v1alpha1"
 	"github.com/movewp3/keycloakclient-controller/pkg/common"
@@ -405,9 +406,7 @@ func keycloakClientDeprecatedClientSecretTest() error {
 		return errors.Wrap(ErrDeprecatedClientSecretFound, secret.Name)
 	}
 
-	// verify client secret removal
-	var retrievedSecret v1.Secret
-	err = GetNamespacedSecret(keycloakNamespace, secret.Name, &retrievedSecret)
+	_, err = GetSecret(secret.Name)
 	if !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -458,9 +457,6 @@ func keycloakClientWithSecretSeedTest() error {
 		return errors.Wrap(ErrSecretSetInKeycloakclient, client.Spec.Client.ClientID)
 	}
 
-	// verify client secret removal
-	var retrievedSecret v1.Secret
-
 	list, err := ListSecret()
 	for i, item := range list.Items {
 		fmt.Println("secrets found " + strconv.Itoa(i) + " " + item.Name)
@@ -468,17 +464,9 @@ func keycloakClientWithSecretSeedTest() error {
 
 	secretName := "keycloak-client-secret-" + testKeycloakConfidentialClientCRName
 	fmt.Println("search secret  " + keycloakNamespace + " " + secretName)
-	err = GetNamespacedSecret(keycloakNamespace, secretName, &retrievedSecret)
+	retrievedSecret, err := GetSecret(secretName)
 	if err != nil {
 		fmt.Println("error search secret  " + keycloakNamespace + " " + secretName + " " + err.Error())
-	}
-	secretName = testKeycloakCRName + "-client-secret-" + testKeycloakConfidentialClientCRName
-
-	fmt.Println("search secret  " + keycloakNamespace + " " + secretName)
-	err = GetNamespacedSecret(keycloakNamespace, secretName, &retrievedSecret)
-	if err != nil {
-		fmt.Println("error search secret  " + keycloakNamespace + " " + secretName + " " + err.Error())
-		return err
 	}
 
 	expectedSecret, _ := controllers.GetClientShaCode(client.Spec.Client.ClientID)

--- a/test/e2e/keycloaks_test.go
+++ b/test/e2e/keycloaks_test.go
@@ -102,21 +102,6 @@ func getExternalKeycloakSecret(namespace string) (*v1.Secret, error) {
 	return getClient().CoreV1().Secrets(namespace).Get(context.TODO(), "credential-"+testKeycloakCRName, metav1.GetOptions{})
 }
 
-func prepareUnmanagedKeycloaksCR(namespace string) error {
-	keycloakCR := getUnmanagedKeycloakCR(namespace)
-	err := CreateKeycloak(keycloakCR)
-	if err != nil {
-		return err
-	}
-
-	err = WaitForKeycloakToBeReady(namespace, testKeycloakCRName)
-	if err != nil {
-		return err
-	}
-
-	return err
-}
-
 func prepareExternalKeycloaksCR() error {
 	keycloakURL := "http://keycloak.local:80"
 	// 8082

--- a/test/e2e/keycloaks_test.go
+++ b/test/e2e/keycloaks_test.go
@@ -127,7 +127,7 @@ func prepareExternalKeycloaksCR() error {
 		Type: v1.SecretTypeOpaque,
 	}
 
-	err = CreateSecret(secret)
+	_, err = CreateSecret(secret)
 	Expect(err).To(BeNil())
 	GinkgoWriter.Printf("secret created\n")
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -14,7 +14,6 @@ import (
 	"github.com/movewp3/keycloakclient-controller/api/v1alpha1"
 	keycloakv1alpha1 "github.com/movewp3/keycloakclient-controller/api/v1alpha1"
 	"github.com/movewp3/keycloakclient-controller/pkg/client/clientset/versioned"
-
 	v1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -262,6 +261,10 @@ func DeleteSecret(name string) error {
 func CreateSecret(secret *v1.Secret) error {
 	_, err := getClient().CoreV1().Secrets(keycloakNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
 	return err
+}
+func ListSecret() (*v1.SecretList, error) {
+	opts := metav1.ListOptions{}
+	return getClient().CoreV1().Secrets(keycloakNamespace).List(context.Background(), opts)
 }
 
 func GetKeycloak(name string) (*keycloakv1alpha1.Keycloak, error) {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -271,9 +271,10 @@ func GetKeycloak(name string) (*keycloakv1alpha1.Keycloak, error) {
 	return getKeycloakApiClient().KeycloakV1alpha1().Keycloaks(keycloakNamespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
-func GetNamespacedSecret(namespace string, objectName string, outputObject *v1.Secret) error {
-	return getClient().RESTClient().Get().Namespace(namespace).Resource("Secret").Name(objectName).Do(context.Background()).Into(outputObject)
+func GetSecret(objectName string) (*v1.Secret, error) {
+	return getClient().CoreV1().Secrets(keycloakNamespace).Get(context.Background(), objectName, metav1.GetOptions{})
 }
+
 func GetNamespacedKeycloak(namespace string, name string) (*keycloakv1alpha1.Keycloak, error) {
 	return getKeycloakApiClient().KeycloakV1alpha1().Keycloaks(namespace).Get(context.Background(), name, metav1.GetOptions{})
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -258,9 +258,9 @@ func CreateKeycloakClient(kcc *keycloakv1alpha1.KeycloakClient) (*keycloakv1alph
 func DeleteSecret(name string) error {
 	return getClient().CoreV1().Secrets(keycloakNamespace).Delete(context.Background(), name, metav1.DeleteOptions{})
 }
-func CreateSecret(secret *v1.Secret) error {
-	_, err := getClient().CoreV1().Secrets(keycloakNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
-	return err
+func CreateSecret(secret *v1.Secret) (*v1.Secret, error) {
+	secret, err := getClient().CoreV1().Secrets(keycloakNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	return secret, err
 }
 func ListSecret() (*v1.SecretList, error) {
 	opts := metav1.ListOptions{}


### PR DESCRIPTION
The controller now supports a secret seed.
If the secret seed is specified, the secret for a KeycloakClient is created based on sha(secretseed+clietname+salt).
THis helps if the controller has to run in two clusters and should create the same secret for the keycloakclient in both clusters