### PR TITLE
feat: [PACLOUD-386] Support Multiple Additional Default Client Scopes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21.11 as builder
+FROM golang:1.21.11 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ A basic configuration for the keycloakcontroller consists of
   
 * optional secret credential-keycloak-client-secret-seed in namespace des controllers
   * SECRET_SEED if the secret for each client should be created via a sha code of (secret-seed + client-name). This is sometimes necessary if a controller should be running in twho separate k8s clusters.
-* optional defaultClientScope for public KeycloakClients. For KeycloakClients, the defaultClientScopes are usually configured in the KeycloakClient CustomResource.
-If a certain defaultClientScope is needed in every KeycloakClient, e.g. the Scope "Nonce" for all the public KeycloakClients after the Keycloak25 Update, then this can be configured with the environment Variable ADDITIONAL_DEFAULT_CLIENT_SCOPE and in the case the value "Nonce" (without changing all the KeycloakClient CustomResources)
+* optional defaultClientScopes for public KeycloakClients. For KeycloakClients, the defaultClientScopes are usually configured in the KeycloakClient CustomResource.
+If a certain defaultClientScope is needed in every KeycloakClient, e.g. the Scopes "Nonce" and "basic" for all the public KeycloakClients after the Keycloak25 Update, then this can be configured with the environment Variable ADDITIONAL_DEFAULT_CLIENT_SCOPES and in the case the value "Nonce,basic" (without changing all the KeycloakClient CustomResources)
 
 
 


### PR DESCRIPTION
Allow to specify multiple additional DefaultClientScopes that have to be added to every public KeycloakClient